### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @llm-jp/modelwg


### PR DESCRIPTION
Reviewへの追加自動化のため、`.github/CODEOWNERS`ファイルを追加しました
[参考](https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

CODEOWNERSには @llm-jp/modelwg のチームが追加されています

@hiroshi-matsuda-rit 
GitHub Teamをレビュアーとして追加するために、そのチームに対してリポジトリへの書き込み権限を追加する必要があるようなのですが、お手隙の際に @llm-jp/modelwg に対してこのリポジトリへの書き込み権限を追加していただけないでしょうか
